### PR TITLE
Change to quay.io in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ### Easy way (Docker Image)
 You can simply run this docker image to test SiteBroker without installing python packages system-wide or in a virtualenv.
 
-    docker run -it --rm aminvakil/sitebroker
+    docker run -it --rm quay.io/aminvakil/sitebroker
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 ### Easy way (Docker Image)
 You can simply run this docker image to test SiteBroker without installing python packages system-wide or in a virtualenv.
 
-    docker run -it --rm quay.io/aminvakil/sitebroker
+    docker build -t sitebroker .
+    docker run -it --rm sitebroker
 
 ### Requirements
 


### PR DESCRIPTION
Docker hub is going to restrict access to its public repositories starting from November.